### PR TITLE
Fix 1 error and 1 typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ We also support the following two datasets:
 Get a list of filenames for each dataset.
 
 ```sh
-find data/sod/SOD -type f -name *.mid -o -name *.xml | cut -c 14- > data/sod/original-names.txt
+find data/sod/SOD -type f -name '*.mid' -o -name '*.xml' | cut -c 14- > data/sod/original-names.txt
 ```
 
 > Note: Change the number in the cut command for different datasets.
@@ -68,7 +68,7 @@ find data/sod/SOD -type f -name *.mid -o -name *.xml | cut -c 14- > data/sod/ori
 Convert the MIDI and MusicXML files into MusPy files for processing.
 
 ```sh
-python convert_sod.py
+python mmt/convert_sod.py
 ```
 
 > Note: You may enable multiprocessing with the `-j` option, for example, `python convert_sod.py -j 10` for 10 parallel jobs.
@@ -78,7 +78,7 @@ python convert_sod.py
 Extract a list of notes from the MusPy JSON files.
 
 ```sh
-python extract.py -d sod
+python mmt/extract.py -d sod
 ```
 
 ### Split training/validation/test sets
@@ -86,7 +86,7 @@ python extract.py -d sod
 Split the processed data into training, validation and test sets.
 
 ```sh
-python split.py -d sod
+python mmt/split.py -d sod
 ```
 
 ## Preprocessed Datasets

--- a/mmt/extract.py
+++ b/mmt/extract.py
@@ -72,10 +72,10 @@ def extract(name, in_dir, out_dir, resolution):
     (out_dir / name).parent.mkdir(exist_ok=True)
 
     # Save the notes as a CSV file
-    representation.save_csv_notes((out_dir / name).with_suffix("csv"), notes)
+    representation.save_csv_notes((out_dir / name).with_suffix(".csv"), notes)
 
     # Save the notes as a NPY file
-    np.save((out_dir / name).with_suffix("npy"), notes)
+    np.save((out_dir / name).with_suffix(".npy"), notes)
 
     return name
 

--- a/mmt/train.py
+++ b/mmt/train.py
@@ -204,7 +204,7 @@ def main():
             args.out_dir = pathlib.Path(f"exp/test_{args.dataset}")
 
     # Make sure the output directory exists
-    args.out_dir.mkdir(exist_ok=True)
+    args.out_dir.mkdir(parents=True, exist_ok=True)
     (args.out_dir / "checkpoints").mkdir(exist_ok=True)
 
     # Set up the logger


### PR DESCRIPTION
Hi!
I fixed 1 error and 1 typo(or error)

## error
- [commit](https://github.com/salu133445/mmt/pull/2/commits/62168be8e861b6f174f19daa4919cd4a779b6acd)

The suffix of the with_suffix method in pathlib.py should start with ".". The original code gave me an error, so I added a ".".
The following code is part of the pathlib.py of Python3.9

```
    def with_suffix(self, suffix):
        ...
        if suffix and not suffix.startswith('.') or suffix == '.':
            raise ValueError("Invalid suffix %r" % (suffix))
        ...
```

## typo
- [commit](https://github.com/salu133445/mmt/pull/2/commits/c11da7492fcc79ca633dfa6574782f04daa62888)

The original shell scripts in README didn't work. So, I
- used quotes to ensure consistent behavior
- changed to the correct path for .py file